### PR TITLE
Configure worker application logging

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,13 +7,8 @@ system_group: workers
 celery_user: celery
 gunicorn_user: gunicorn
 
-gunicorn_logging_directory: /var/log/gunicorn
-
-celery_logging_directory: /var/log/celery
 celery_pid_file: /tmp/%n.pid
 celery_beat_pid_file: /tmp/beat.pid
-celery_log_level: INFO
-celery_log_file: "{{ celery_logging_directory }}/celery_app.log"
 
 site_packages:
   - bash-completion

--- a/roles/celery/templates/celery.service
+++ b/roles/celery/templates/celery.service
@@ -6,13 +6,10 @@ After=network.target
 Type=forking
 User={{ celery_user }}
 Environment={{ env_file_var }}={{ repository_path }}/.env
-Environment=DJANGO_APP_LOG_DIR={{ celery_logging_directory }}
 WorkingDirectory={{ repository_path }}
 ExecStart={{ virtualenv_dir }}/bin/celery multi start worker1 \
 -A mtdj.celery \
 --pidfile={{ celery_pid_file }} \
---loglevel={{ celery_log_level }} \
---logfile={{ celery_log_file }}
 
 ExecStop={{ virtualenv_dir }}/bin/celery multi stopwait worker1 \
 --pidfile={{ celery_pid_file }}
@@ -20,8 +17,6 @@ ExecStop={{ virtualenv_dir }}/bin/celery multi stopwait worker1 \
 ExecReload={{ virtualenv_dir }}/bin/celery multi restart worker1 \
 -A mtdj.celery \
 --pidfile={{ celery_pid_file }} \
---loglevel={{ celery_log_level }} \
---logfile={{ celery_log_file }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/celery/templates/celery.service
+++ b/roles/celery/templates/celery.service
@@ -10,13 +10,19 @@ WorkingDirectory={{ repository_path }}
 ExecStart={{ virtualenv_dir }}/bin/celery multi start worker1 \
 -A mtdj.celery \
 --pidfile={{ celery_pid_file }} \
+--loglevel=INFO \
+--logfile={{ logging_dir }}/celery.log
 
 ExecStop={{ virtualenv_dir }}/bin/celery multi stopwait worker1 \
 --pidfile={{ celery_pid_file }}
+--loglevel=INFO \
+--logfile={{ logging_dir }}/celery.log
 
 ExecReload={{ virtualenv_dir }}/bin/celery multi restart worker1 \
 -A mtdj.celery \
 --pidfile={{ celery_pid_file }} \
+--loglevel=INFO \
+--logfile={{ logging_dir }}/celery.log
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/celery/templates/celery_beat.service
+++ b/roles/celery/templates/celery_beat.service
@@ -6,15 +6,12 @@ After=network.target
 Type=forking
 User={{ celery_user }}
 Environment={{ env_file_var }}={{ repository_path }}/.env
-Environment=DJANGO_APP_LOG_DIR={{ celery_logging_directory }}
 WorkingDirectory={{ repository_path }}
 ExecStart={{ virtualenv_dir }}/bin/celery multi start worker1 \
 -A mtdj.celery \
 --beat \
 --scheduler=django_celery_beat.schedulers:DatabaseScheduler \
 --pidfile={{ celery_beat_pid_file }} \
---loglevel={{ celery_log_level }} \
---logfile={{ celery_log_file }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/celery/templates/celery_beat.service
+++ b/roles/celery/templates/celery_beat.service
@@ -12,6 +12,8 @@ ExecStart={{ virtualenv_dir }}/bin/celery multi start worker1 \
 --beat \
 --scheduler=django_celery_beat.schedulers:DatabaseScheduler \
 --pidfile={{ celery_beat_pid_file }} \
+--loglevel=INFO \
+--logfile={{ logging_dir }}/celery.log
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/gunicorn/templates/gunicorn.service
+++ b/roles/gunicorn/templates/gunicorn.service
@@ -9,8 +9,6 @@ Environment={{ env_file_var }}={{ repository_path }}/.env
 ExecStart={{ virtualenv_dir }}/bin/gunicorn \
 --name={{ app_name }} \
 --pythonpath={{ virtualenv_dir}}/bin/python \
---access-logfile={{ gunicorn_logging_directory }}/access.log \
---error-logfile={{ gunicorn_logging_directory }}/error.log \
 --bind 127.0.0.1:{{ wsgi_server_port }} \
 --config /etc/gunicorn.d/gunicorn.py \
 {{ app_name }}.wsgi:application

--- a/roles/gunicorn/templates/gunicorn.service
+++ b/roles/gunicorn/templates/gunicorn.service
@@ -6,7 +6,6 @@ After=network.target
 User={{ gunicorn_user }}
 WorkingDirectory={{ repository_path }}
 Environment={{ env_file_var }}={{ repository_path }}/.env
-Environment=DJANGO_APP_LOG_DIR={{ gunicorn_logging_directory }}
 ExecStart={{ virtualenv_dir }}/bin/gunicorn \
 --name={{ app_name }} \
 --pythonpath={{ virtualenv_dir}}/bin/python \

--- a/roles/gunicorn/templates/gunicorn.service
+++ b/roles/gunicorn/templates/gunicorn.service
@@ -11,6 +11,8 @@ ExecStart={{ virtualenv_dir }}/bin/gunicorn \
 --pythonpath={{ virtualenv_dir}}/bin/python \
 --bind 127.0.0.1:{{ wsgi_server_port }} \
 --config /etc/gunicorn.d/gunicorn.py \
+--access-logfile=- \
+--error-logfile=- \
 {{ app_name }}.wsgi:application
 
 [Install]

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -27,7 +27,9 @@
   file:
     path: "{{ logging_dir }}"
     owner: "{{ default_user }}"
+    group: "{{ system_group }}"
     state: directory
+    mode: 0770
 
 - name: Create application log file
   become_user: root

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -21,6 +21,26 @@
     owner: "{{ default_user }}"
     state: directory
 
+- name: Create application log file
+  become_user: root
+
+  file:
+    path: "{{ logging_dir }}/application.log"
+    owner: "{{ default_user }}"
+    group: "{{ system_group }}"
+    state: touch
+    mode: 0660
+
+- name: Create application error file
+  become_user: root
+
+  file:
+    path: "{{ logging_dir }}/error.log"
+    owner: "{{ default_user }}"
+    group: "{{ system_group }}"
+    state: touch
+    mode: 0660
+
 - name: Create celery logging directory
   become_user: root
 

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -13,6 +13,14 @@
     groups: "{{ system_group }}"
     create_home: no
 
+- name: Create gunicorn user
+  become_user: root
+
+  user:
+    name: "{{ gunicorn_user }}"
+    groups: "{{ system_group }}"
+    create_home: no
+
 - name: Configure logging path
   become_user: root
 
@@ -40,30 +48,6 @@
     group: "{{ system_group }}"
     state: touch
     mode: 0660
-
-- name: Create celery logging directory
-  become_user: root
-
-  file:
-    path: "{{ celery_logging_directory }}"
-    owner: "{{ celery_user }}"
-    state: directory
-
-- name: Create gunicorn user
-  become_user: root
-
-  user:
-    name: "{{ gunicorn_user }}"
-    groups: "{{ system_group }}"
-    create_home: no
-
-- name: Create gunicorn logging directory
-  become_user: root
-
-  file:
-    path: "{{ gunicorn_logging_directory }}"
-    owner: "{{ gunicorn_user }}"
-    state: directory
 
 - name: Add application startup script
 

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -29,27 +29,7 @@
     owner: "{{ default_user }}"
     group: "{{ system_group }}"
     state: directory
-    mode: 0770
-
-- name: Create application log file
-  become_user: root
-
-  file:
-    path: "{{ logging_dir }}/application.log"
-    owner: "{{ default_user }}"
-    group: "{{ system_group }}"
-    state: touch
-    mode: 0660
-
-- name: Create application error file
-  become_user: root
-
-  file:
-    path: "{{ logging_dir }}/error.log"
-    owner: "{{ default_user }}"
-    group: "{{ system_group }}"
-    state: touch
-    mode: 0660
+    mode: u=rwx,g=rwx,o=rx,g+s
 
 - name: Add application startup script
 


### PR DESCRIPTION
NOTE

Currently we have gunicorn writing its log messages to the gunicorn log directory and the application logs to the mtdj log directory.

We should also configure celery to follow the same practice