### PR TITLE
Use proper flow for setting new user password

### DIFF
--- a/roles/users/tasks/create_users.yml
+++ b/roles/users/tasks/create_users.yml
@@ -11,18 +11,11 @@
 
   user:
     name: "{{ item.name }}"
+    password: ""  # Set using `passwd` on first login
     shell: "{{ item.shell }}"
     groups: "{{ item.groups }}"
     home: "{{ item.home }}"
     update_password: on_create
-
-  with_items:
-    - "{{ users }}"
-
-- name: Unlock password and set to empty
-  become_user: root
-
-  command: passwd -d "{{ item.name }}"
 
   with_items:
     - "{{ users }}"


### PR DESCRIPTION
Old flow reset password on each provision
New users will use the passwd command to set their password on
first login