### PR TITLE
Add regexp argument to task to lookup Github public key

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -6,6 +6,7 @@
     path: "{{ home_directory }}/.ssh/known_hosts"
     create: true
     state: present
+    regexp: "^github\\.com"
     line: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
 
 - name: Clone repository


### PR DESCRIPTION
Should avoid looking up key if it is already in known_hosts config