### PR TITLE
Change permissions of application directory

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,7 +7,6 @@ ansible_python_interpreter: /usr/bin/python3
 system_group: workers
 staff_group: staff
 
-mtdj_user: mtdj
 celery_user: celery
 gunicorn_user: gunicorn
 

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -50,10 +50,10 @@
 
   file:
     path: "{{ application_directory }}"
-    owner: "{{ mtdj_user }}"
+    owner: "{{ provisioning_user }}"
     group: "{{ system_group }}"
     state: directory
-    mode: u=rwx,g=rwx,g+s
+    mode: u=rwx,g=rwx
 
 - name: Configure logging path
   become: true

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -17,15 +17,6 @@
     groups: "{{ system_group }}"
     append: yes
 
-- name: Create mtdj user
-  become: true
-  become_user: root
-
-  user:
-    name: "{{ mtdj_user }}"
-    groups: "{{ system_group }}"
-    create_home: false
-
 - name: Create celery user
   become: true
   become_user: root


### PR DESCRIPTION
Using an `mtdj` user creates more problems than it solves. Change the owner of the application directory to the provisioning user