### PR TITLE
Move nginx conf to sites-available

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -6,6 +6,17 @@
 
   template:
     src: templates/nginx.j2
-    dest: /etc/nginx/conf.d/{{ app_name }}.conf
+    dest: /etc/nginx/sites-available/{{ app_name }}.conf
+
+  notify: restart nginx
+
+- name: Create symlink to nginx conf
+  become: true
+  become_user: root
+
+  file:
+    src: /etc/nginx/sites-available/{{ app_name }}.conf
+    dest: /etc/nginx/sites-enabled/default
+    state: link
 
   notify: restart nginx

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -5,17 +5,27 @@
   become_user: root
 
   template:
-    src: templates/nginx.j2
-    dest: /etc/nginx/sites-available/{{ app_name }}.conf
+    src: templates/conf.j2
+    dest: /etc/nginx/conf.d/{{ app_name }}.conf
 
   notify: restart nginx
 
-- name: Create symlink to nginx conf
+- name: Create nginx application server conf
+  become: true
+  become_user: root
+
+  template:
+    src: templates/nginx.j2
+    dest: /etc/nginx/sites-available/{{ app_hostname }}
+
+  notify: restart nginx
+
+- name: Create symlink to application server conf
   become: true
   become_user: root
 
   file:
-    src: /etc/nginx/sites-available/{{ app_name }}.conf
+    src: /etc/nginx/sites-available/{{ app_hostname }}
     dest: /etc/nginx/sites-enabled/default
     state: link
 

--- a/roles/nginx/templates/conf.j2
+++ b/roles/nginx/templates/conf.j2
@@ -1,0 +1,1 @@
+server_tokens off;

--- a/roles/nginx/templates/conf.j2
+++ b/roles/nginx/templates/conf.j2
@@ -1,1 +1,10 @@
 server_tokens off;
+
+ssl_certificate {{ cert_path }};
+ssl_certificate_key {{ privatekey_path }};
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+ssl_ecdh_curve secp521r1:secp384r1;
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 24h;
+ssl_session_tickets off;
+ssl_buffer_size 1400;

--- a/roles/nginx/templates/nginx.j2
+++ b/roles/nginx/templates/nginx.j2
@@ -1,5 +1,3 @@
-server_tokens off;
-
 upstream app_server {
     server 127.0.0.1:{{ wsgi_server_port }} fail_timeout=0;
 }

--- a/roles/nginx/templates/nginx.j2
+++ b/roles/nginx/templates/nginx.j2
@@ -15,17 +15,6 @@ server {
         return 405;
     }
 
-    ssl_certificate {{ cert_path }};
-    ssl_certificate_key {{ privatekey_path }};
-    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
-    ssl_protocols TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_ecdh_curve secp521r1:secp384r1;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 24h;
-    ssl_session_tickets off;
-    ssl_buffer_size 1400;
-
     keepalive_timeout 5;
 
     location /static {
@@ -67,19 +56,6 @@ server {
 server {
     listen 443 ssl;
     server_name www.{{ app_hostname }};
-
-    # TODO: Can we refactor these SSL variables to a common config?
-    # Shared by both this server block and the "main" block
-    ssl_certificate {{ cert_path }};
-    ssl_certificate_key {{ privatekey_path }};
-    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
-    ssl_protocols TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_ecdh_curve secp521r1:secp384r1;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 24h;
-    ssl_session_tickets off;
-    ssl_buffer_size 1400;
 
     return 301 https://{{ app_hostname }}$request_uri;
 }


### PR DESCRIPTION
NOTE:

Need to delete the old config file in `/etc/nginx/conf.d/mtdj.conf` before deploying this. Having both in place causes nginx to error out.

UPDATE: Since we're overwriting the `etc/nginx/conf.d/mtdj.conf` file with the nginx config for the site, it seems to work OK since we're clearing out the old application server config.