### PR TITLE
Add admin subdomain to HTTP server name

### DIFF
--- a/group_vars/local
+++ b/group_vars/local
@@ -5,7 +5,7 @@ node_use_development: yes
 
 # TLS Certificate generation variables
 ssl_path: /etc/ssl
-cert_path: "{{ ssl_path }}/certs/ansible.com.crt"
-privatekey_path: "{{ ssl_path }}/private/ansible.com.pem"
-csr_path: "{{ ssl_path }}/csr/ansible.com.csr"
+cert_path: "{{ ssl_path }}/certs/{{ app_hostname }}.crt"
+privatekey_path: "{{ ssl_path }}/private/{{ app_hostname }}.pem"
+csr_path: "{{ ssl_path }}/csr/{{ app_hostname }}.csr"
 ssl_config_path: "{{ ssl_path }}/self-signed.conf"

--- a/group_vars/mtdj_prod
+++ b/group_vars/mtdj_prod
@@ -12,8 +12,8 @@ spotify_redirect_uri: https://moodytunes.us/moodytunes/spotify/callback/
 
 # LetsEncrypt certificate variables
 ssl_path: /etc/letsencrypt/live
-cert_path: "{{ ssl_path }}/moodytunes.us/fullchain.pem"
-privatekey_path: "{{ ssl_path }}/moodytunes.us/privkey.pem"
+cert_path: "{{ ssl_path }}/{{ app_hostname }}/fullchain.pem"
+privatekey_path: "{{ ssl_path }}/{{ app_hostname }}/privkey.pem"
 
 app_debug: False
 celery_always_eager: False

--- a/roles/nginx/templates/nginx.j2
+++ b/roles/nginx/templates/nginx.j2
@@ -6,10 +6,10 @@ upstream app_server {
 
 server {
     listen 443 ssl;
-    server_name {{ app_hostname }} www.{{ app_hostname }} admin.{{ app_hostname }};
+    server_name {{ app_hostname }} admin.{{ app_hostname }};
 
     # Deny invalid Host headers
-    if ($host !~* ^({{ app_hostname }}|www.{{ app_hostname }}|admin.{{ app_hostname }})$) {
+    if ($host !~* ^({{ app_hostname }}|admin.{{ app_hostname }})$) {
         return 444;
     }
 
@@ -54,11 +54,34 @@ server {
 
 server {
     listen 80;
-    server_name {{ app_hostname }} www.{{ app_hostname }} admin.{{ app_hostname }};
+    server_name {{ app_hostname }} www.{{ app_hostname }};
 
-    if ($request_method !~ ^(GET|POST|DELETE|HEAD)$) {
-        return 405;
-    }
+    return 301 https://{{ app_hostname }}$request_uri;
+}
 
-    return 301 https://$host$request_uri;
+server {
+    listen 80;
+    server_name admin.{{ app_hostname }};
+
+    return 301 https://admin.{{ app_hostname }}$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name www.{{ app_hostname }};
+
+    # TODO: Can we refactor these SSL variables to a common config?
+    # Shared by both this server block and the "main" block
+    ssl_certificate {{ cert_path }};
+    ssl_certificate_key {{ privatekey_path }};
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ecdh_curve secp521r1:secp384r1;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 24h;
+    ssl_session_tickets off;
+    ssl_buffer_size 1400;
+
+    return 301 https://{{ app_hostname }}$request_uri;
 }

--- a/roles/nginx/templates/nginx.j2
+++ b/roles/nginx/templates/nginx.j2
@@ -54,19 +54,11 @@ server {
 
 server {
     listen 80;
-    server_name {{ app_hostname }} www.{{ app_hostname }};
+    server_name {{ app_hostname }} www.{{ app_hostname }} admin.{{ app_hostname }} www.admin.{{ app_hostname }};
 
     if ($request_method !~ ^(GET|POST|DELETE|HEAD)$) {
         return 405;
     }
 
-    if ($host = www.{{ app_hostname }}) {
-        return 301 https://{{ app_hostname }}$request_uri;
-    }
-
-    if ($host = {{ app_hostname }}) {
-        return 301 https://$host$request_uri;
-    }
-
-    return 404;
+    return 301 https://$host$request_uri;
 }

--- a/roles/nginx/templates/nginx.j2
+++ b/roles/nginx/templates/nginx.j2
@@ -54,7 +54,7 @@ server {
 
 server {
     listen 80;
-    server_name {{ app_hostname }} www.{{ app_hostname }} admin.{{ app_hostname }} www.admin.{{ app_hostname }};
+    server_name {{ app_hostname }} www.{{ app_hostname }} admin.{{ app_hostname }};
 
     if ($request_method !~ ^(GET|POST|DELETE|HEAD)$) {
         return 405;

--- a/roles/openssl/tasks/selfsign.yml
+++ b/roles/openssl/tasks/selfsign.yml
@@ -23,7 +23,7 @@
   openssl_csr:
     path: "{{ csr_path }}"
     privatekey_path: "{{ privatekey_path }}"
-    common_name: www.{{ app_hostname }}
+    common_name: "{{ app_hostname }}"
 
 - name: Generate self signed certificate
   become: true


### PR DESCRIPTION
Fix issues where requests to `admin.moodytunes.vm` weren't properly handled because the listener for HTTP requests wasn't aware of the admin subdomain.