### PR TITLE
Add task to check for GitHub public key before doing lookup

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,5 +1,6 @@
 home_directory: /home/{{ provisioning_user }}
 application_directory: /srv/mtdj
+known_hosts_file: "{{ home_directory }}/.ssh/known_hosts"
 
 python_path: /usr/bin/python3.6
 ansible_python_interpreter: /usr/bin/python3

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -21,3 +21,4 @@
     dest: "{{ repository_path }}"
     repo: "{{ repository_url }}"
     version: "{{ git_version }}"
+    ssh_opts: -o AddressFamily=inet

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,13 +1,18 @@
 ---
 
-- name: Add Github to known hosts
+- name: Check if Github is in known_hosts file
 
-  lineinfile:
-    path: "{{ home_directory }}/.ssh/known_hosts"
-    create: true
-    state: present
-    regexp: "^github\\.com"
-    line: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
+  shell: ssh-keygen -f {{ known_hosts_file }} -F github.com
+
+  register: github_known_host_result
+  ignore_errors: true
+  no_log: true
+
+- name: Add Github public key to known_hosts if it is not present
+
+  shell: ssh-keyscan -H -T 10 github.com >> {{ known_hosts_file }}
+
+  when: github_known_host_result.failed
 
 - name: Clone repository
 

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -11,7 +11,12 @@
 
 - name: Add Github public key to known_hosts if it is not present
 
-  shell: ssh-keyscan -H -T 10 github.com >> {{ known_hosts_file }}
+  lineinfile:
+    path: "{{ known_hosts_file }}"
+    create: true
+    state: present
+    regexp: "^github\\.com"
+    line: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
 
   when: github_known_host_result.failed
 

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -2,11 +2,12 @@
 
 - name: Check if Github is in known_hosts file
 
-  shell: ssh-keygen -f {{ known_hosts_file }} -F github.com
+  command: ssh-keygen -f {{ known_hosts_file }} -F github.com
 
   register: github_known_host_result
   ignore_errors: true
   no_log: true
+  changed_when: github_known_host_result.failed
 
 - name: Add Github public key to known_hosts if it is not present
 


### PR DESCRIPTION
Should be more peformant as we'd only do the lookup for Github's
public key if we do not have an entry for Github in known_hosts