### PR TITLE
Set proper permissions on env file

### DIFF
--- a/host_vars/moodytunes
+++ b/host_vars/moodytunes
@@ -11,6 +11,7 @@ celery_pid_directory: /var/run/celery
 celery_pid_file: "{{ celery_pid_directory}}/%n.pid"
 celery_user: celery
 database_backup_path: /var/mtdj/backups
+env_file_path: /etc/mtdj.env
 env_file_var: MTDJ_ENV_FILE
 gunicorn_user: gunicorn
 home_directory: /home/{{ provisioning_user }}

--- a/roles/celery/templates/celery.service
+++ b/roles/celery/templates/celery.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 User={{ celery_user }}
-Environment={{ env_file_var }}={{ repository_path }}/.env
+Environment={{ env_file_var }}={{ env_file_path }}
 WorkingDirectory={{ repository_path }}
 ExecStart={{ virtualenv_dir }}/bin/celery multi start celery-worker \
 -A mtdj.celery \

--- a/roles/celery/templates/celery_beat.service
+++ b/roles/celery/templates/celery_beat.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User={{ celery_user }}
-Environment={{ env_file_var }}={{ repository_path }}/.env
+Environment={{ env_file_var }}={{ env_file_path }}
 WorkingDirectory={{ repository_path }}
 ExecStart={{ virtualenv_dir }}/bin/celery beat \
 -A mtdj.celery \

--- a/roles/env/tasks/main.yml
+++ b/roles/env/tasks/main.yml
@@ -20,7 +20,12 @@
     requirements: "{{ requirements_file }}"
 
 - name: Create environment variables list
+  become: true
+  become_user: root
 
   template:
     src: templates/env
-    dest: "{{ repository_path }}/.env"
+    dest: /etc/mtdj.env
+    owner: "{{ provisioning_user }}"
+    group: "{{ system_group }}"
+    mode: 0440

--- a/roles/env/tasks/main.yml
+++ b/roles/env/tasks/main.yml
@@ -25,7 +25,7 @@
 
   template:
     src: templates/env
-    dest: /etc/mtdj.env
+    dest: "{{ env_file_path }}"
     owner: "{{ provisioning_user }}"
     group: "{{ system_group }}"
     mode: 0440

--- a/roles/gunicorn/templates/gunicorn.service
+++ b/roles/gunicorn/templates/gunicorn.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ gunicorn_user }}
 WorkingDirectory={{ repository_path }}
-Environment={{ env_file_var }}={{ repository_path }}/.env
+Environment={{ env_file_var }}={{ env_file_path }}
 ExecStart={{ virtualenv_dir }}/bin/gunicorn \
 --name={{ app_name }} \
 --pythonpath={{ virtualenv_dir}}/bin/python \

--- a/templates/bash_templates/application-startup
+++ b/templates/bash_templates/application-startup
@@ -1,3 +1,3 @@
 . {{ virtualenv_source }}
-export {{ env_file_var }}="{{ repository_path }}/.env"
+export {{ env_file_var }}="{{ env_file_path }}"
 cd {{ repository_path }}


### PR DESCRIPTION
- Move env file for storing application variables to `/etc/mtdj.env`
- Set file permissions to read-only for provision user and system group, disable read/writes for all other users

Tested that the env file can still be written during provisioning so we can add variables to the file with ansible