### PR TITLE
Set postgresql server timezone to same value used in application

### DIFF
--- a/roles/postgres/templates/postgresql.conf.j2
+++ b/roles/postgres/templates/postgresql.conf.j2
@@ -565,7 +565,7 @@ stats_temp_directory = '/var/run/postgresql/10-main.pg_stat_tmp'
 
 datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
-timezone = 'Etc/UTC'
+timezone = 'UTC'
 #timezone_abbreviations = 'Default'     # Select the set of available time zone
 					# abbreviations.  Currently, there are
 					#   Default


### PR DESCRIPTION
Avoid Django having to make separate query to set timezone